### PR TITLE
Add functional calculator web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# app-financas-V4
+# Calculadora Web
+
+Projeto de uma calculadora responsiva desenvolvida com HTML, CSS e JavaScript puro. A aplicação oferece operações básicas, suporte a teclado e exibe histórico das operações realizadas.
+
+## Como executar
+
+1. Abra o arquivo `index.html` diretamente no navegador **ou** sirva a pasta com um servidor estático, por exemplo:
+   ```bash
+   python -m http.server 8000
+   ```
+2. Acesse `http://localhost:8000` para utilizar a calculadora.
+
+## Funcionalidades
+
+- Operações de soma, subtração, multiplicação e divisão.
+- Teclas de porcentagem, inversão de sinal, limpar e igual.
+- Entrada via teclado com suporte a vírgula como separador decimal.
+- Histórico da operação atual e formatação de números no padrão brasileiro.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calculadora</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="calculator" aria-label="Calculadora básica">
+      <header class="calculator__display" aria-live="polite">
+        <div class="calculator__history" id="calc-history"></div>
+        <output id="calc-display" class="calculator__output">0</output>
+      </header>
+      <section class="calculator__keys">
+        <button type="button" data-action="clear" class="key key--function">AC</button>
+        <button type="button" data-action="sign" class="key key--function">±</button>
+        <button type="button" data-action="percent" class="key key--function">%</button>
+        <button type="button" data-action="operator" data-value="/" class="key key--operator">÷</button>
+
+        <button type="button" data-action="digit" data-value="7" class="key">7</button>
+        <button type="button" data-action="digit" data-value="8" class="key">8</button>
+        <button type="button" data-action="digit" data-value="9" class="key">9</button>
+        <button type="button" data-action="operator" data-value="*" class="key key--operator">×</button>
+
+        <button type="button" data-action="digit" data-value="4" class="key">4</button>
+        <button type="button" data-action="digit" data-value="5" class="key">5</button>
+        <button type="button" data-action="digit" data-value="6" class="key">6</button>
+        <button type="button" data-action="operator" data-value="-" class="key key--operator">−</button>
+
+        <button type="button" data-action="digit" data-value="1" class="key">1</button>
+        <button type="button" data-action="digit" data-value="2" class="key">2</button>
+        <button type="button" data-action="digit" data-value="3" class="key">3</button>
+        <button type="button" data-action="operator" data-value="+" class="key key--operator">+</button>
+
+        <button type="button" data-action="digit" data-value="0" class="key key--zero">0</button>
+        <button type="button" data-action="decimal" class="key">,</button>
+        <button type="button" data-action="equals" class="key key--equals">=</button>
+      </section>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,234 @@
+const display = document.querySelector('#calc-display');
+const history = document.querySelector('#calc-history');
+const keys = document.querySelector('.calculator__keys');
+
+const state = {
+  displayValue: '0',
+  firstOperand: null,
+  operator: null,
+  awaitingSecondOperand: false,
+  history: '',
+};
+
+const performCalculation = {
+  '+': (a, b) => a + b,
+  '-': (a, b) => a - b,
+  '*': (a, b) => a * b,
+  '/': (a, b) => (b === 0 ? NaN : a / b),
+};
+
+function updateDisplay() {
+  display.textContent = formatNumber(state.displayValue);
+  history.textContent = state.history;
+}
+
+function formatNumber(value) {
+  if (value === 'Erro') return value;
+  const [integerPart = '0', decimalPart] = value.split('.');
+  const isNegative = integerPart.startsWith('-');
+  const sanitizedInteger = isNegative ? integerPart.slice(1) : integerPart;
+  const formattedInteger = Number(sanitizedInteger || '0').toLocaleString('pt-BR');
+  const sign = isNegative ? '-' : '';
+
+  if (decimalPart !== undefined) {
+    const decimalText = decimalPart === '' ? '' : decimalPart;
+    return `${sign}${formattedInteger},${decimalText}`;
+  }
+
+  return `${sign}${formattedInteger}`;
+}
+
+function inputDigit(digit) {
+  if (state.awaitingSecondOperand) {
+    state.displayValue = digit;
+    state.awaitingSecondOperand = false;
+  } else {
+    state.displayValue =
+      state.displayValue === '0' ? digit : state.displayValue + digit;
+  }
+}
+
+function inputDecimal() {
+  if (state.awaitingSecondOperand) {
+    state.displayValue = '0.';
+    state.awaitingSecondOperand = false;
+    return;
+  }
+  if (!state.displayValue.includes('.')) {
+    state.displayValue += '.';
+  }
+}
+
+function handleOperator(nextOperator) {
+  const inputValue = parseFloat(state.displayValue);
+
+  if (state.operator && state.awaitingSecondOperand) {
+    state.operator = nextOperator;
+    state.history = `${formatHistoryValue(state.firstOperand)} ${symbolForOperator(nextOperator)}`;
+    return;
+  }
+
+  if (state.firstOperand === null && !Number.isNaN(inputValue)) {
+    state.firstOperand = inputValue;
+  } else if (state.operator) {
+    const currentValue = state.firstOperand || 0;
+    const result = performCalculation[state.operator](currentValue, inputValue);
+    if (Number.isNaN(result) || !Number.isFinite(result)) {
+      state.displayValue = 'Erro';
+      resetState();
+      updateDisplay();
+      return;
+    }
+    state.displayValue = String(roundResult(result));
+    state.firstOperand = parseFloat(state.displayValue);
+  }
+
+  state.awaitingSecondOperand = true;
+  state.operator = nextOperator;
+  state.history = `${formatHistoryValue(state.firstOperand)} ${symbolForOperator(nextOperator)}`;
+}
+
+function formatHistoryValue(value) {
+  return Number(value).toLocaleString('pt-BR');
+}
+
+function symbolForOperator(operator) {
+  return (
+    {
+      '+': '+',
+      '-': '−',
+      '*': '×',
+      '/': '÷',
+    }[operator] || operator
+  );
+}
+
+function handleEquals() {
+  const inputValue = parseFloat(state.displayValue);
+
+  if (state.operator === null || state.awaitingSecondOperand) {
+    return;
+  }
+
+  const result = performCalculation[state.operator](state.firstOperand, inputValue);
+  if (Number.isNaN(result) || !Number.isFinite(result)) {
+    state.displayValue = 'Erro';
+    resetState();
+    updateDisplay();
+    return;
+  }
+
+  state.displayValue = String(roundResult(result));
+  state.history = `${formatHistoryValue(state.firstOperand)} ${symbolForOperator(state.operator)} ${formatHistoryValue(inputValue)} =`;
+  state.firstOperand = null;
+  state.operator = null;
+  state.awaitingSecondOperand = false;
+}
+
+function handlePercent() {
+  const value = parseFloat(state.displayValue);
+  if (Number.isNaN(value)) return;
+  state.displayValue = String(roundResult(value / 100));
+}
+
+function handleSign() {
+  if (state.displayValue === '0') return;
+  if (state.displayValue.startsWith('-')) {
+    state.displayValue = state.displayValue.slice(1);
+  } else {
+    state.displayValue = `-${state.displayValue}`;
+  }
+}
+
+function clearDisplay() {
+  state.displayValue = '0';
+  state.firstOperand = null;
+  state.operator = null;
+  state.awaitingSecondOperand = false;
+  state.history = '';
+}
+
+function resetState() {
+  state.firstOperand = null;
+  state.operator = null;
+  state.awaitingSecondOperand = false;
+  state.history = '';
+}
+
+function roundResult(value) {
+  return Number.parseFloat(value.toFixed(10));
+}
+
+function handleKeyPress(value) {
+  if (/^[0-9]$/.test(value)) {
+    inputDigit(value);
+  } else if (value === '.') {
+    inputDecimal();
+  } else if (value in performCalculation) {
+    handleOperator(value);
+  } else if (value === 'Enter' || value === '=') {
+    handleEquals();
+  } else if (value === 'Escape') {
+    clearDisplay();
+  } else if (value === '%') {
+    handlePercent();
+  } else if (value === 'Backspace') {
+    backspace();
+  }
+  updateDisplay();
+}
+
+function backspace() {
+  if (state.awaitingSecondOperand) return;
+  if (state.displayValue.length <= 1 || (state.displayValue.length === 2 && state.displayValue.startsWith('-'))) {
+    state.displayValue = '0';
+  } else {
+    state.displayValue = state.displayValue.slice(0, -1);
+  }
+}
+
+keys.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!target.closest('button')) return;
+  const action = target.dataset.action;
+  const value = target.dataset.value;
+
+  switch (action) {
+    case 'digit':
+      inputDigit(value);
+      break;
+    case 'decimal':
+      inputDecimal();
+      break;
+    case 'operator':
+      handleOperator(value);
+      break;
+    case 'equals':
+      handleEquals();
+      break;
+    case 'percent':
+      handlePercent();
+      break;
+    case 'sign':
+      handleSign();
+      break;
+    case 'clear':
+      clearDisplay();
+      break;
+    default:
+      break;
+  }
+  updateDisplay();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === ',') {
+    event.preventDefault();
+    inputDecimal();
+    updateDisplay();
+    return;
+  }
+  handleKeyPress(event.key);
+});
+
+updateDisplay();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.4;
+  --bg: #1e1e1e;
+  --panel: #2b2b2b;
+  --panel-light: #f5f5f5;
+  --accent: #ff9500;
+  --accent-text: #ffffff;
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.6);
+  --shadow: rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #eceff1;
+    --panel: #ffffff;
+    --panel-light: #ffffff;
+    --accent: #ff9500;
+    --accent-text: #ffffff;
+    --text-primary: #212121;
+    --text-secondary: rgba(33, 33, 33, 0.5);
+    --shadow: rgba(0, 0, 0, 0.2);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, rgba(255, 149, 0, 0.2), transparent), var(--bg);
+  color: var(--text-primary);
+}
+
+.calculator {
+  background: var(--panel);
+  border-radius: 24px;
+  width: min(360px, 90vw);
+  box-shadow: 0 20px 40px var(--shadow);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.calculator__display {
+  display: grid;
+  gap: 0.4rem;
+  text-align: right;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), transparent);
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+}
+
+.calculator__history {
+  min-height: 1.2rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.calculator__output {
+  font-size: clamp(2.2rem, 8vw, 3.4rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.calculator__keys {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.key {
+  border: none;
+  border-radius: 999px;
+  padding: 1rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.key:active {
+  transform: scale(0.96);
+}
+
+.key:focus-visible {
+  outline: 2px solid rgba(255, 149, 0, 0.6);
+  outline-offset: 3px;
+}
+
+.key--function {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.key--operator {
+  background: rgba(255, 149, 0, 0.15);
+  color: var(--accent);
+}
+
+.key--equals {
+  background: var(--accent);
+  color: var(--accent-text);
+}
+
+.key--zero {
+  grid-column: span 2;
+}
+
+@media (max-width: 400px) {
+  .calculator {
+    padding: 1.2rem;
+    gap: 1.2rem;
+  }
+
+  .key {
+    padding-block: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive calculator layout with semantic HTML and styling
- implement calculator logic with keyboard support and localized formatting
- document usage instructions and features in the README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d68e3ef3e08325a6affc157608ad42