### PR TITLE
Handle missing Firebase configuration gracefully

### DIFF
--- a/config/firebaseConfig.js
+++ b/config/firebaseConfig.js
@@ -1,28 +1,83 @@
 (function injectFirebaseConfig() {
+  const REQUIRED_KEYS = [
+    'apiKey',
+    'authDomain',
+    'projectId',
+    'storageBucket',
+    'messagingSenderId',
+    'appId'
+  ];
+
+  const normalize = (value) => (typeof value === 'string' ? value.trim() : value);
+  const hasAllRequiredKeys = (config) =>
+    !!config &&
+    REQUIRED_KEYS.every((key) => {
+      const value = normalize(config[key]);
+      return value !== undefined && value !== null && value !== '';
+    });
+
+  const getMissingKeys = (config) =>
+    REQUIRED_KEYS.filter((key) => {
+      const value = config ? normalize(config[key]) : undefined;
+      return value === undefined || value === null || value === '';
+    });
+
   const script = document.currentScript;
-  if (!script) {
-    console.error('Firebase configuration script must be loaded directly in the page.');
+  const existingConfig = window.__FIREBASE_CONFIG__;
+
+  const candidateConfigs = [];
+
+  if (existingConfig) {
+    candidateConfigs.push(existingConfig);
+  }
+
+  if (window.__APP_FIREBASE_CONFIG__) {
+    candidateConfigs.push(window.__APP_FIREBASE_CONFIG__);
+  }
+
+  const inlineConfigElement = document.getElementById('firebase-config');
+  if (inlineConfigElement) {
+    try {
+      const parsed = JSON.parse(inlineConfigElement.textContent || '{}');
+      candidateConfigs.push(parsed);
+    } catch (error) {
+      console.error('Failed to parse inline Firebase configuration JSON.', error);
+      window.__FIREBASE_CONFIG_ERROR__ = 'Não foi possível interpretar a configuração inline do Firebase. Verifique o JSON informado.';
+    }
+  }
+
+  if (script) {
+    const datasetConfig = {
+      apiKey: normalize(script.dataset.firebaseApiKey),
+      authDomain: normalize(script.dataset.firebaseAuthDomain),
+      projectId: normalize(script.dataset.firebaseProjectId),
+      storageBucket: normalize(script.dataset.firebaseStorageBucket),
+      messagingSenderId: normalize(script.dataset.firebaseMessagingSenderId),
+      appId: normalize(script.dataset.firebaseAppId)
+    };
+    candidateConfigs.push(datasetConfig);
+  }
+
+  const resolvedConfig = candidateConfigs.find((config) => hasAllRequiredKeys(config));
+
+  if (resolvedConfig) {
+    window.__FIREBASE_CONFIG__ = resolvedConfig;
+    window.__FIREBASE_CONFIG_ERROR__ = undefined;
     return;
   }
 
-  const firebaseConfig = {
-    apiKey: script.dataset.firebaseApiKey || '',
-    authDomain: script.dataset.firebaseAuthDomain || '',
-    projectId: script.dataset.firebaseProjectId || '',
-    storageBucket: script.dataset.firebaseStorageBucket || '',
-    messagingSenderId: script.dataset.firebaseMessagingSenderId || '',
-    appId: script.dataset.firebaseAppId || ''
-  };
+  const lastCandidate = candidateConfigs[candidateConfigs.length - 1];
+  const missingKeys = getMissingKeys(lastCandidate);
 
-  const missingKeys = Object.entries(firebaseConfig)
-    .filter(([, value]) => !value)
-    .map(([key]) => key);
-
-  if (missingKeys.length > 0) {
-    const message = `Firebase configuration is incomplete. Missing: ${missingKeys.join(', ')}`;
-    console.error(message);
-    throw new Error(message);
+  let message;
+  if (!candidateConfigs.length) {
+    message = 'Firebase configuration was not provided. Informe as credenciais via data-attributes, JSON inline ou variável global __APP_FIREBASE_CONFIG__.';
+  } else if (missingKeys.length > 0) {
+    message = `Firebase configuration is incomplete. Missing: ${missingKeys.join(', ')}.`;
+  } else {
+    message = 'Firebase configuration could not be resolved.';
   }
 
-  window.__FIREBASE_CONFIG__ = firebaseConfig;
+  console.error(message);
+  window.__FIREBASE_CONFIG_ERROR__ = message;
 })();

--- a/index.html
+++ b/index.html
@@ -26,6 +26,18 @@
     </div>
 
     <!-- Tela de Login -->
+    <div id="critical-error-screen" class="hidden fixed inset-0 z-[2500] bg-white/95 backdrop-blur-sm flex flex-col items-center justify-center px-6 text-center">
+        <div class="max-w-xl w-full bg-white/80 border border-gray-200 rounded-2xl shadow-xl p-8">
+            <h2 class="text-2xl font-bold text-[var(--color-text-dark)] mb-4">Não foi possível iniciar o aplicativo</h2>
+            <p id="critical-error-message" class="text-gray-600 text-sm md:text-base mb-6">
+                Verifique a configuração do Firebase e recarregue a página.
+            </p>
+            <button id="retry-initialization-button" class="hidden w-full md:w-auto bg-[var(--color-blue-primary)] text-white font-semibold py-3 px-6 rounded-lg hover:bg-opacity-90 transition">
+                Tentar novamente
+            </button>
+        </div>
+    </div>
+
     <div id="login-screen" class="hidden fixed inset-0 bg-gray-100 z-[1500] flex items-center justify-center p-4">
         <div class="w-full max-w-md bg-white p-8 rounded-2xl shadow-xl">
             <h2 class="text-3xl font-bold text-center text-[var(--color-text-dark)] mb-2">Bem-vindo!</h2>


### PR DESCRIPTION
## Summary
- make the Firebase config loader fall back to global variables or inline JSON and report missing keys without throwing
- add a full-screen critical error overlay to inform the user when initialization cannot continue
- guard the Firebase bootstrap logic to surface configuration issues gracefully and halt the rest of the app setup

## Testing
- not run (web app)


------
https://chatgpt.com/codex/tasks/task_e_68d6c46813e88325ae37e89e5ab8578c