### PR TITLE
Fix firebase config syntax error

### DIFF
--- a/config/firebaseConfig.js
+++ b/config/firebaseConfig.js
@@ -6,7 +6,7 @@
   storageBucket: "offline-d2e68.firebasestorage.app",
   messagingSenderId: "524684058670",
   appId: "1:524684058670:web:5141130aee53e059cc7fbf"
-  ];
+  };
 
   const normalize = (value) => (typeof value === 'string' ? value.trim() : value);
   const hasAllRequiredKeys = (config) =>


### PR DESCRIPTION
## Summary
- replace the incorrect closing bracket in the Firebase config object with the proper brace terminator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c9a56afc8325acf6d3160cd67062