### PR TITLE
Define REQUIRED_KEYS constant

### DIFF
--- a/config/firebaseConfig.js
+++ b/config/firebaseConfig.js
@@ -8,6 +8,8 @@
   appId: "1:524684058670:web:5141130aee53e059cc7fbf"
   ];
 
+  const REQUIRED_KEYS = ['apiKey','authDomain','projectId','storageBucket','messagingSenderId','appId'];
+
   const normalize = (value) => (typeof value === 'string' ? value.trim() : value);
   const hasAllRequiredKeys = (config) =>
     !!config &&


### PR DESCRIPTION
## Summary
- declare the REQUIRED_KEYS array before the normalization helpers in the Firebase config loader
- ensure the script can reference REQUIRED_KEYS when validating candidate configurations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6c9b3bf248325bf39c4489e643197