### PR TITLE
Refine AI guidance and financial summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
                 <div class="bg-white p-6 rounded-xl shadow-md">
                     <div class="mb-4">
                         <label for="ai-persona" class="block text-sm font-medium text-gray-700 mb-1">Personagem (Papel)</label>
-                        <textarea id="ai-persona" rows="4" class="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Ex: Você é um educador financeiro especialista..."></textarea>
+                        <textarea id="ai-persona" rows="4" class="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Ex: Você é uma mentora financeira que ajuda um casal a cortar supérfluos e proteger o essencial."></textarea>
                     </div>
                     <div class="mb-6">
                         <label for="ai-personality" class="block text-sm font-medium text-gray-700 mb-1">Personalidade (Tom)</label>


### PR DESCRIPTION
## Summary
- expand the financial data shared with the assistant to highlight monthly essentials, não-essenciais, orçamentos e caixinhas
- align default persona and prompts to focus on economia, corte de gastos e priorização do essencial sem realizar cálculos
- adjust insight, notificação e otimização de orçamento para manter instruções consistentes e seguras

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6d1654bd08325ad843cbee56aa843