### PR TITLE
Relax Gemini key invalidation on transient errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
                 <div class="bg-white p-6 rounded-xl shadow-md">
                     <div class="mb-4">
                         <label for="ai-persona" class="block text-sm font-medium text-gray-700 mb-1">Personagem (Papel)</label>
-                        <textarea id="ai-persona" rows="4" class="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Ex: Você é um educador financeiro especialista..."></textarea>
+                        <textarea id="ai-persona" rows="4" class="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Ex: Você é uma mentora financeira que ajuda um casal a cortar supérfluos e proteger o essencial."></textarea>
                     </div>
                     <div class="mb-6">
                         <label for="ai-personality" class="block text-sm font-medium text-gray-700 mb-1">Personalidade (Tom)</label>
@@ -596,19 +596,21 @@
         <div class="modal-content relative">
             <span id="close-api-keys-modal" class="close-button">&times;</span>
             <h2 class="text-2xl font-bold mb-2">Gerenciar Chaves de API Gemini</h2>
-            <p class="text-gray-500 mb-4">Insira até 5 chaves de API. O sistema alternará entre elas para evitar limites de uso.</p>
+            <p class="text-gray-500 mb-4">Insira até 5 chaves de API. O sistema alternará entre elas e colocará em pausa automática quando o limite for atingido.</p>
             <div id="api-modal-status-message" class="hidden p-4 mb-4 text-sm rounded-lg" role="alert">
                 <span id="api-modal-message-text"></span>
             </div>
             <div class="space-y-3">
-                 <input type="text" id="modal-api-key-1" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 1">
-                 <input type="text" id="modal-api-key-2" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 2">
-                 <input type="text" id="modal-api-key-3" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 3">
-                 <input type="text" id="modal-api-key-4" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 4">
-                 <input type="text" id="modal-api-key-5" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 5">
+                <input type="text" id="modal-api-key-1" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 1">
+                <input type="text" id="modal-api-key-2" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 2">
+                <input type="text" id="modal-api-key-3" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 3">
+                <input type="text" id="modal-api-key-4" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 4">
+                <input type="text" id="modal-api-key-5" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 5">
             </div>
-            <div class="flex justify-end mt-6">
-                <button id="save-api-keys-modal-button" class="bg-[var(--color-blue-primary)] text-white font-bold py-2 px-4 rounded-lg">Salvar Chaves</button>
+            <div id="api-key-status-list" class="hidden mt-4 text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3 space-y-2"></div>
+            <div class="flex flex-col gap-3 mt-6 sm:flex-row sm:items-center sm:justify-between">
+                <button id="reset-api-key-status-button" class="w-full sm:w-auto bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors">Liberar chaves em pausa</button>
+                <button id="save-api-keys-modal-button" class="w-full sm:w-auto bg-[var(--color-blue-primary)] text-white font-bold py-2 px-4 rounded-lg">Salvar Chaves</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -39,9 +39,26 @@ let aiConfig = {
 // Múltiplas chaves de API Gemini (ARRAY)
 let geminiApiKeys = []; 
 let currentGeminiApiKeyIndex = 0; // Índice da chave de API atualmente em uso
-let chatHistory = []; 
+let chatHistory = [];
 let isSendingMessage = false;
-let isGeminiApiReady = false; 
+let isGeminiApiReady = false;
+
+// Controle avançado das chaves Gemini
+const GEMINI_API_KEY_STATUS = {
+    AVAILABLE: 'available',
+    COOLDOWN: 'cooldown',
+    INVALID: 'invalid'
+};
+const GEMINI_API_RATE_LIMIT_COOLDOWN_MINUTES = 65;
+const GEMINI_API_SERVER_ERROR_COOLDOWN_MINUTES = 5;
+const GEMINI_API_NETWORK_COOLDOWN_MINUTES = 2;
+const GEMINI_API_MAX_RETRIES_PER_KEY = 3;
+const GEMINI_API_KEY_HEALTH_STORAGE_KEY = 'financasClarasGeminiKeyHealth';
+
+let geminiApiKeyHealth = loadGeminiApiKeyHealth();
+let apiKeyStatusListElement = null;
+let scheduleApiKeyUiRefresh = null;
+let hasWarnedAllKeysBlocked = false;
 
 // Flag e armazenamento para dados financeiros para a IA
 let hasConsultedFinancialData = false;
@@ -70,6 +87,325 @@ const CAIXINHA_COLORS = ['#a29bfe', '#74b9ff', '#81ecec', '#ffeaa7', '#00cec9', 
 let aiSuggestedExpensesQueue = [];
 // NOVO: Armazenamento para as sugestões de otimização de categoria
 let categoryOptimizationSuggestionsStore = [];
+
+
+function loadGeminiApiKeyHealth() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+    try {
+        const stored = localStorage.getItem(GEMINI_API_KEY_HEALTH_STORAGE_KEY);
+        return stored ? JSON.parse(stored) : [];
+    } catch (error) {
+        console.warn('Não foi possível ler o status das chaves Gemini do armazenamento local.', error);
+        return [];
+    }
+}
+
+function persistGeminiApiKeyHealth() {
+    if (typeof localStorage === 'undefined') {
+        return;
+    }
+    try {
+        localStorage.setItem(GEMINI_API_KEY_HEALTH_STORAGE_KEY, JSON.stringify(geminiApiKeyHealth));
+    } catch (error) {
+        console.warn('Não foi possível salvar o status das chaves Gemini no armazenamento local.', error);
+    }
+}
+
+function fingerprintKey(key) {
+    if (!key) return null;
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+        hash = ((hash << 5) - hash) + key.charCodeAt(i);
+        hash |= 0;
+    }
+    return hash.toString();
+}
+
+function createApiKeyHealthState(rawKey) {
+    const trimmedKey = (rawKey || '').trim();
+    if (!trimmedKey) {
+        return {
+            fingerprint: null,
+            status: GEMINI_API_KEY_STATUS.AVAILABLE,
+            disabledUntil: null,
+            failureReason: null,
+            failureCount: 0
+        };
+    }
+    return {
+        fingerprint: fingerprintKey(trimmedKey),
+        status: GEMINI_API_KEY_STATUS.AVAILABLE,
+        disabledUntil: null,
+        failureReason: null,
+        failureCount: 0
+    };
+}
+
+function ensureGeminiApiKeyHealth(index) {
+    const trimmedKey = (geminiApiKeys[index] || '').trim();
+    const fingerprint = trimmedKey ? fingerprintKey(trimmedKey) : null;
+    const existing = geminiApiKeyHealth[index];
+    if (existing && existing.fingerprint === fingerprint) {
+        return existing;
+    }
+    const newState = createApiKeyHealthState(trimmedKey);
+    geminiApiKeyHealth[index] = newState;
+    return newState;
+}
+
+function syncGeminiApiKeyHealthWithKeys() {
+    geminiApiKeyHealth = geminiApiKeys.map((rawKey, index) => {
+        const trimmedKey = (rawKey || '').trim();
+        if (!trimmedKey) {
+            return createApiKeyHealthState('');
+        }
+        const fingerprint = fingerprintKey(trimmedKey);
+        const existing = geminiApiKeyHealth[index];
+        if (existing && existing.fingerprint === fingerprint) {
+            if (existing.status === GEMINI_API_KEY_STATUS.INVALID) {
+                return {
+                    ...existing,
+                    fingerprint,
+                    status: GEMINI_API_KEY_STATUS.AVAILABLE,
+                    disabledUntil: null,
+                    failureReason: null,
+                    failureCount: 0
+                };
+            }
+            return { ...existing, fingerprint };
+        }
+        return createApiKeyHealthState(trimmedKey);
+    });
+    persistGeminiApiKeyHealth();
+    if (typeof scheduleApiKeyUiRefresh === 'function') {
+        scheduleApiKeyUiRefresh();
+    }
+}
+
+function getAvailableGeminiKeyEntries(options = {}) {
+    const { skipUiRefresh = false } = options;
+    const now = Date.now();
+    const availableEntries = [];
+    let stateChanged = false;
+
+    geminiApiKeys.forEach((rawKey, index) => {
+        const trimmedKey = (rawKey || '').trim();
+        if (!trimmedKey) {
+            return;
+        }
+
+        let state = geminiApiKeyHealth[index];
+        if (!state || state.fingerprint !== fingerprintKey(trimmedKey)) {
+            state = ensureGeminiApiKeyHealth(index);
+            stateChanged = true;
+        }
+
+        if (state.status === GEMINI_API_KEY_STATUS.COOLDOWN && state.disabledUntil && state.disabledUntil <= now) {
+            geminiApiKeyHealth[index] = {
+                ...state,
+                status: GEMINI_API_KEY_STATUS.AVAILABLE,
+                disabledUntil: null,
+                failureReason: null
+            };
+            state = geminiApiKeyHealth[index];
+            stateChanged = true;
+        }
+
+        if (state.status === GEMINI_API_KEY_STATUS.AVAILABLE) {
+            availableEntries.push({ key: trimmedKey, index });
+        }
+    });
+
+    if (stateChanged) {
+        persistGeminiApiKeyHealth();
+        if (!skipUiRefresh && typeof scheduleApiKeyUiRefresh === 'function') {
+            scheduleApiKeyUiRefresh();
+        }
+    }
+
+    return availableEntries;
+}
+
+function hasAvailableGeminiKey(options = {}) {
+    return getAvailableGeminiKeyEntries(options).length > 0;
+}
+
+function markApiKeyAsHealthy(index) {
+    const state = ensureGeminiApiKeyHealth(index);
+    geminiApiKeyHealth[index] = {
+        ...state,
+        status: GEMINI_API_KEY_STATUS.AVAILABLE,
+        disabledUntil: null,
+        failureReason: null,
+        failureCount: 0
+    };
+    persistGeminiApiKeyHealth();
+    hasWarnedAllKeysBlocked = false;
+    if (typeof scheduleApiKeyUiRefresh === 'function') {
+        scheduleApiKeyUiRefresh();
+    }
+}
+
+function markApiKeyAsCoolingDown(index, minutes, reason) {
+    const state = ensureGeminiApiKeyHealth(index);
+    const cooldownMinutes = Math.max(1, minutes || 1);
+    geminiApiKeyHealth[index] = {
+        ...state,
+        status: GEMINI_API_KEY_STATUS.COOLDOWN,
+        disabledUntil: Date.now() + cooldownMinutes * 60 * 1000,
+        failureReason: reason || null,
+        failureCount: (state.failureCount || 0) + 1
+    };
+    persistGeminiApiKeyHealth();
+    if (typeof scheduleApiKeyUiRefresh === 'function') {
+        scheduleApiKeyUiRefresh();
+    }
+}
+
+function markApiKeyAsInvalid(index, reason) {
+    const state = ensureGeminiApiKeyHealth(index);
+    geminiApiKeyHealth[index] = {
+        ...state,
+        status: GEMINI_API_KEY_STATUS.INVALID,
+        disabledUntil: null,
+        failureReason: reason || 'Chave inválida ou sem permissão.',
+        failureCount: (state.failureCount || 0) + 1
+    };
+    persistGeminiApiKeyHealth();
+    if (typeof scheduleApiKeyUiRefresh === 'function') {
+        scheduleApiKeyUiRefresh();
+    }
+}
+
+function resetApiKeyHealth(includeInvalid = true) {
+    geminiApiKeyHealth = geminiApiKeys.map((rawKey, index) => {
+        const trimmedKey = (rawKey || '').trim();
+        if (!trimmedKey) {
+            return createApiKeyHealthState('');
+        }
+        const fingerprint = fingerprintKey(trimmedKey);
+        const existing = geminiApiKeyHealth[index];
+        if (existing && existing.fingerprint === fingerprint) {
+            if (existing.status === GEMINI_API_KEY_STATUS.INVALID && !includeInvalid) {
+                return existing;
+            }
+            return {
+                ...existing,
+                status: GEMINI_API_KEY_STATUS.AVAILABLE,
+                disabledUntil: null,
+                failureReason: null,
+                failureCount: 0
+            };
+        }
+        return createApiKeyHealthState(trimmedKey);
+    });
+    persistGeminiApiKeyHealth();
+    hasWarnedAllKeysBlocked = false;
+    if (typeof scheduleApiKeyUiRefresh === 'function') {
+        scheduleApiKeyUiRefresh();
+    }
+}
+
+function maskApiKey(key) {
+    if (!key) return '';
+    const trimmed = key.trim();
+    if (trimmed.length <= 8) return trimmed;
+    return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
+}
+
+function formatCooldownMessage(disabledUntil) {
+    if (!disabledUntil) {
+        return 'pausada temporariamente';
+    }
+    const now = Date.now();
+    if (disabledUntil <= now) {
+        return 'liberada novamente';
+    }
+    const diffMs = disabledUntil - now;
+    const totalMinutes = Math.round(diffMs / 60000);
+    const untilTime = new Date(disabledUntil).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+
+    if (totalMinutes >= 60) {
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+        if (minutes === 0) {
+            return `pausada por ${hours}h (até ${untilTime})`;
+        }
+        return `pausada por ${hours}h ${minutes}min (até ${untilTime})`;
+    }
+
+    if (totalMinutes <= 1) {
+        const seconds = Math.max(30, Math.round(diffMs / 1000));
+        return `pausada por ${seconds}s (até ${untilTime})`;
+    }
+
+    return `pausada por ${totalMinutes} min (até ${untilTime})`;
+}
+
+function renderApiKeyStatusList() {
+    if (!apiKeyStatusListElement) {
+        return;
+    }
+
+    const configuredKeys = geminiApiKeys
+        .map((rawKey, index) => ({ key: (rawKey || '').trim(), index }))
+        .filter(entry => entry.key);
+
+    if (configuredKeys.length === 0) {
+        apiKeyStatusListElement.innerHTML = '';
+        apiKeyStatusListElement.classList.add('hidden');
+        return;
+    }
+
+    const availableCount = getAvailableGeminiKeyEntries({ skipUiRefresh: true }).length;
+
+    const itemsHtml = configuredKeys.map(({ key, index }) => {
+        const state = ensureGeminiApiKeyHealth(index);
+        let statusTitle = 'Ativa';
+        let statusClass = 'text-green-600';
+        let extraInfo = '';
+
+        if (state.status === GEMINI_API_KEY_STATUS.COOLDOWN) {
+            statusTitle = 'Em pausa';
+            statusClass = 'text-amber-600';
+            extraInfo = formatCooldownMessage(state.disabledUntil);
+            if (state.failureReason) {
+                extraInfo += ` · ${state.failureReason}`;
+            }
+        } else if (state.status === GEMINI_API_KEY_STATUS.INVALID) {
+            statusTitle = 'Chave bloqueada';
+            statusClass = 'text-red-600';
+            extraInfo = state.failureReason || 'Chave inválida ou sem permissão.';
+        } else if (state.failureReason) {
+            extraInfo = state.failureReason;
+        }
+
+        const extraInfoHtml = extraInfo
+            ? `<p class="text-[0.7rem] text-gray-500 leading-snug">${extraInfo}</p>`
+            : '';
+
+        return `
+            <div class="pt-2 first:pt-0 first:border-t-0 border-t border-gray-200 flex items-start justify-between gap-3">
+                <div>
+                    <p class="text-sm font-semibold text-gray-700">Chave ${index + 1}</p>
+                    <p class="text-xs text-gray-500 break-all">${maskApiKey(key)}</p>
+                </div>
+                <div class="text-right">
+                    <p class="text-xs font-semibold ${statusClass}">${statusTitle}</p>
+                    ${extraInfoHtml}
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    apiKeyStatusListElement.innerHTML = `
+        <p class="text-xs text-gray-500">Disponíveis agora: ${availableCount} de ${configuredKeys.length}</p>
+        ${itemsHtml}
+    `;
+    apiKeyStatusListElement.classList.remove('hidden');
+}
 
 
 // --- Funções Auxiliares ---
@@ -131,8 +467,9 @@ function getFinancialDataForAI() {
     // Calcula resumos financeiros com base nos dados GLOBAIS
     let totalGlobalIncome = 0;
     let totalGlobalPaidExpenses = 0;
+    const confirmedStatuses = new Set(['Recebido', 'Pago', 'Confirmado']);
     transactions.forEach(t => {
-        const isConfirmed = t.status === 'Recebido' || t.status === 'Pago' || t.status === 'Confirmado';
+        const isConfirmed = confirmedStatuses.has(t.status);
         if (isConfirmed) {
             if (t.type === 'income') totalGlobalIncome += parseFloat(t.amount);
             else if (t.type === 'expense') totalGlobalPaidExpenses += parseFloat(t.amount);
@@ -150,6 +487,88 @@ function getFinancialDataForAI() {
         .filter(cat => cat.type === 'caixinha')
         .reduce((sum, caixinha) => sum + parseFloat(caixinha.savedAmount || 0), 0);
 
+    // --- Resumo detalhado do mês atual ---
+    const today = new Date();
+    const currentMonthKey = getCurrentMonthYYYYMM(today);
+    const monthTransactions = transactions.filter(t => {
+        if (!t.date) return false;
+        const transactionDate = new Date(t.date);
+        if (Number.isNaN(transactionDate.getTime())) return false;
+        return getCurrentMonthYYYYMM(transactionDate) === currentMonthKey;
+    });
+
+    let monthIncome = 0;
+    let monthEssentialExpenses = 0;
+    let monthNonEssentialExpenses = 0;
+    let monthCaixinhaDeposits = 0;
+    let monthCaixinhaWithdrawals = 0;
+    const nonEssentialCategoryTotals = {};
+    const essentialCategoryTotals = {};
+
+    monthTransactions.forEach(t => {
+        const amount = parseFloat(t.amount);
+        if (Number.isNaN(amount)) return;
+        const category = categories.find(cat => cat.id === t.categoryId);
+        const isConfirmed = confirmedStatuses.has(t.status);
+        if (!isConfirmed) return;
+
+        if (t.type === 'income') {
+            monthIncome += amount;
+        } else if (t.type === 'expense') {
+            const isNonEssential = category && category.priority === 'non-essential';
+            if (isNonEssential) {
+                monthNonEssentialExpenses += amount;
+                nonEssentialCategoryTotals[category.id] = (nonEssentialCategoryTotals[category.id] || 0) + amount;
+            } else {
+                monthEssentialExpenses += amount;
+                if (category) {
+                    essentialCategoryTotals[category.id] = (essentialCategoryTotals[category.id] || 0) + amount;
+                }
+            }
+        } else if (t.type === 'caixinha') {
+            if (t.transactionType === 'deposit') monthCaixinhaDeposits += amount;
+            if (t.transactionType === 'withdraw') monthCaixinhaWithdrawals += amount;
+        }
+    });
+
+    const topNonEssentialCategories = Object.entries(nonEssentialCategoryTotals)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([categoryId, total]) => ({
+            name: categoryMap[categoryId] || 'Categoria não identificada',
+            total
+        }));
+
+    const topEssentialPressureCategories = Object.entries(essentialCategoryTotals)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([categoryId, total]) => ({
+            name: categoryMap[categoryId] || 'Categoria não identificada',
+            total
+        }));
+
+    const budgetsThisMonth = budgets.filter(b => b.month === currentMonthKey);
+    const budgetSummaries = budgetsThisMonth.map(budget => {
+        const categoryName = categoryMap[budget.categoryId] || 'Categoria desconhecida';
+        const actualSpent = monthTransactions
+            .filter(t => t.categoryId === budget.categoryId && t.type === 'expense' && confirmedStatuses.has(t.status))
+            .reduce((sum, t) => sum + parseFloat(t.amount), 0);
+        const remaining = budget.amount - actualSpent;
+        return {
+            categoryName,
+            planned: budget.amount,
+            spent: actualSpent,
+            remaining
+        };
+    });
+
+    const caixinhasDetails = categories
+        .filter(cat => cat.type === 'caixinha')
+        .map(cat => ({
+            name: cat.name,
+            saved: parseFloat(cat.savedAmount || 0)
+        }));
+
     // --- FORMATAÇÃO DA STRING PARA A IA ---
     let dataString = `A data de hoje é ${new Date().toLocaleDateString('pt-BR')}.\n\n`;
 
@@ -159,6 +578,49 @@ function getFinancialDataForAI() {
     dataString += `- Quantidade de Despesas Pendentes: ${countPending}\n`;
     dataString += `- Valor Total de Despesas Pendentes: ${formatCurrency(totalPending)}\n`;
     dataString += `- Total Guardado em Caixinhas: ${formatCurrency(totalCaixinhasSaved)}\n\n`;
+
+    // 2. Resumo detalhado do mês atual
+    dataString += "<strong>RESUMO DO MÊS ATUAL (apenas lançamentos confirmados):</strong>\n";
+    dataString += `- Receitas do mês: ${formatCurrency(monthIncome)}\n`;
+    dataString += `- Despesas essenciais do mês: ${formatCurrency(monthEssentialExpenses)}\n`;
+    dataString += `- Despesas não essenciais do mês: ${formatCurrency(monthNonEssentialExpenses)}\n`;
+    dataString += `- Depósitos em caixinhas no mês: ${formatCurrency(monthCaixinhaDeposits)}\n`;
+    dataString += `- Resgates de caixinhas no mês: ${formatCurrency(monthCaixinhaWithdrawals)}\n\n`;
+
+    if (topNonEssentialCategories.length > 0) {
+        dataString += "<strong>Maiores gastos não essenciais do mês:</strong>\n";
+        topNonEssentialCategories.forEach(item => {
+            dataString += `- ${item.name}: ${formatCurrency(item.total)}\n`;
+        });
+    } else {
+        dataString += "Não foram registradas despesas não essenciais confirmadas neste mês.\n";
+    }
+
+    if (topEssentialPressureCategories.length > 0) {
+        dataString += "\n<strong>Categorias essenciais que mais consumiram o orçamento neste mês:</strong>\n";
+        topEssentialPressureCategories.forEach(item => {
+            dataString += `- ${item.name}: ${formatCurrency(item.total)}\n`;
+        });
+    }
+
+    if (budgetSummaries.length > 0) {
+        dataString += "\n<strong>Orçamentos e metas do mês atual:</strong>\n";
+        budgetSummaries.forEach(summary => {
+            const statusText = summary.remaining >= 0
+                ? `Disponível: ${formatCurrency(summary.remaining)}`
+                : `Ultrapassou em ${formatCurrency(Math.abs(summary.remaining))}`;
+            dataString += `- ${summary.categoryName}: Planejado ${formatCurrency(summary.planned)}, Gasto ${formatCurrency(summary.spent)}, ${statusText}\n`;
+        });
+    } else {
+        dataString += "\nNenhum orçamento foi configurado para o mês atual.\n";
+    }
+
+    if (caixinhasDetails.length > 0) {
+        dataString += "\n<strong>Caixinhas e objetivos de poupança:</strong>\n";
+        caixinhasDetails.forEach(detail => {
+            dataString += `- ${detail.name}: Saldo atual ${formatCurrency(detail.saved)}\n`;
+        });
+    }
 
     // 2. Lista de Transações Pendentes (se houver)
     if (countPending > 0) {
@@ -209,60 +671,137 @@ function markNotificationAsSentToday() {
  * @returns {Promise<object>} - O resultado da API em caso de sucesso.
  * @throws {Error} - Se todas as chaves falharem.
  */
-async function tryNextApiKey(payload, attemptIndex = 0, retryCount = 0) {
-    const validKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
-    if (attemptIndex >= validKeys.length) {
-        throw new Error("Todas as chaves de API falharam ou estão sem cota.");
+async function tryNextApiKey(payload) {
+    const availableEntries = getAvailableGeminiKeyEntries();
+    if (availableEntries.length === 0) {
+        const error = new Error('Nenhuma chave de API disponível no momento. Adicione ou libere novas chaves para continuar.');
+        error.code = 'NO_AVAILABLE_KEYS';
+        error.userMessage = 'Todas as chaves de IA estão pausadas ou inválidas. Abra “Mais Opções > Gerenciar Chaves” para revisar, liberar ou incluir novas chaves.';
+        throw error;
     }
 
-    const apiKey = validKeys[attemptIndex];
-    const model = payload.generationConfig && payload.generationConfig.response_mime_type === "application/json" ? "gemini-1.5-flash-latest" : "gemini-1.5-flash-latest";
-    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-    
-    console.log(`Tentando API com a chave ${attemptIndex + 1} (Tentativa ${retryCount + 1}) e modelo ${model}...`);
+    let lastError = null;
 
-    try {
-        const response = await fetch(apiUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
-        });
+    for (let entryIndex = 0; entryIndex < availableEntries.length; entryIndex++) {
+        const { key: apiKey, index: originalIndex } = availableEntries[entryIndex];
+        const model = payload.generationConfig && payload.generationConfig.response_mime_type === "application/json"
+            ? "gemini-1.5-flash-latest"
+            : "gemini-1.5-flash-latest";
+        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
-        if (!response.ok) {
-            const errorResult = await response.json();
-            const errorMessage = errorResult.error ? errorResult.error.message : response.statusText;
-            console.error(`Erro da API com a chave ${attemptIndex + 1}:`, errorMessage);
+        console.log(`Tentando API com a chave ${originalIndex + 1} (posição original) usando o modelo ${model}.`);
 
-            // Erros que indicam que devemos tentar a PRÓXIMA chave imediatamente (ex: chave inválida, suspensa)
-            if (response.status === 400 || response.status === 403) {
-                 console.warn(`Chave ${attemptIndex + 1} inválida ou suspensa. Pulando para a próxima.`);
-                 return tryNextApiKey(payload, attemptIndex + 1, 0); // Tenta a próxima chave, reseta a contagem de retentativas
+        for (let retry = 0; retry < GEMINI_API_MAX_RETRIES_PER_KEY; retry++) {
+            try {
+                const response = await fetch(apiUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+
+                if (!response.ok) {
+                    let errorResult = null;
+                    try {
+                        errorResult = await response.json();
+                    } catch (jsonError) {
+                        console.warn('Não foi possível interpretar a resposta de erro da API Gemini.', jsonError);
+                    }
+                    const errorMessage = (errorResult && errorResult.error && errorResult.error.message) || response.statusText || 'Erro desconhecido.';
+                    console.error(`Erro da API com a chave ${originalIndex + 1}:`, errorMessage);
+
+                    if (response.status === 429) {
+                        markApiKeyAsCoolingDown(originalIndex, GEMINI_API_RATE_LIMIT_COOLDOWN_MINUTES, 'Limite gratuito atingido');
+                        const rateLimitError = new Error(`Limite de uso atingido na chave ${originalIndex + 1}.`);
+                        rateLimitError.code = 'RATE_LIMIT';
+                        rateLimitError.userMessage = 'O limite gratuito da chave foi atingido. A chave ficará pausada por um tempo e tentaremos outras automaticamente.';
+                        lastError = rateLimitError;
+                        break; // passa para a próxima chave disponível
+                    }
+
+                    if (response.status === 400) {
+                        const badRequestError = new Error(errorMessage);
+                        badRequestError.code = 'BAD_REQUEST';
+                        badRequestError.userMessage = 'A IA não conseguiu entender o pedido atual. Tente reformular a mensagem sem números ou cálculos.';
+                        lastError = badRequestError;
+                        break;
+                    }
+
+                    if (response.status === 401 || response.status === 403) {
+                        markApiKeyAsInvalid(originalIndex, 'Chave inválida ou sem permissão.');
+                        const invalidError = new Error(`Chave ${originalIndex + 1} inválida ou sem permissão.`);
+                        invalidError.code = 'INVALID_KEY';
+                        invalidError.userMessage = 'Uma das chaves foi recusada pela API. Revise ou substitua as chaves em “Mais Opções > Gerenciar Chaves”.';
+                        lastError = invalidError;
+                        break;
+                    }
+
+                    if (response.status === 404) {
+                        const notFoundError = new Error('Modelo de IA indisponível no momento.');
+                        notFoundError.code = 'MODEL_NOT_FOUND';
+                        notFoundError.userMessage = 'O modelo de IA solicitado não está disponível. Tente novamente em instantes.';
+                        lastError = notFoundError;
+                        break;
+                    }
+
+                    if ((response.status === 500 || response.status === 503) && retry < GEMINI_API_MAX_RETRIES_PER_KEY - 1) {
+                        const delay = Math.pow(2, retry) * 1000 + Math.random() * 500;
+                        console.warn(`API instável (status ${response.status}). Tentando novamente a mesma chave em ${Math.round(delay / 1000)}s.`);
+                        await new Promise(resolve => setTimeout(resolve, delay));
+                        continue;
+                    }
+
+                    if (response.status === 500 || response.status === 503) {
+                        markApiKeyAsCoolingDown(originalIndex, GEMINI_API_SERVER_ERROR_COOLDOWN_MINUTES, 'Instabilidade do serviço');
+                        const serviceError = new Error('Serviço Gemini instável no momento.');
+                        serviceError.code = 'SERVICE_UNAVAILABLE';
+                        serviceError.userMessage = 'A API Gemini está instável. Tentaremos outra chave ou aguarde alguns minutos.';
+                        lastError = serviceError;
+                        break;
+                    }
+
+                    const genericError = new Error(errorMessage);
+                    genericError.code = `HTTP_${response.status}`;
+                    genericError.userMessage = `Erro ${response.status} ao usar a chave atual. Tentaremos outra chave disponível.`;
+                    lastError = genericError;
+                    break;
+                }
+
+                const result = await response.json();
+                currentGeminiApiKeyIndex = originalIndex;
+                markApiKeyAsHealthy(originalIndex);
+                console.log(`Chave ${originalIndex + 1} respondeu com sucesso.`);
+                return result;
+            } catch (error) {
+                console.error(`Erro de rede com a chave ${originalIndex + 1}:`, error);
+                if (retry < GEMINI_API_MAX_RETRIES_PER_KEY - 1) {
+                    const delay = Math.pow(2, retry) * 1000 + Math.random() * 500;
+                    console.warn(`Repetindo tentativa com a mesma chave em ${Math.round(delay / 1000)}s devido a falha de rede.`);
+                    await new Promise(resolve => setTimeout(resolve, delay));
+                    continue;
+                }
+                markApiKeyAsCoolingDown(originalIndex, GEMINI_API_NETWORK_COOLDOWN_MINUTES, 'Falha de rede');
+                const networkError = new Error('Falha de rede ao contactar a API Gemini.');
+                networkError.code = 'NETWORK_ERROR';
+                networkError.userMessage = 'Falha de rede ao contactar a IA. Tentaremos outra chave ou tente novamente em instantes.';
+                lastError = networkError;
+                break;
             }
-
-            // Erros que indicam que devemos TENTAR NOVAMENTE a MESMA chave (ex: sobrecarga, erro de servidor)
-            if ((response.status === 429 || response.status === 503) && retryCount < 3) {
-                const delay = Math.pow(2, retryCount) * 1000 + Math.random() * 1000; // Exponential backoff
-                console.warn(`Serviço sobrecarregado. Tentando novamente a chave ${attemptIndex + 1} em ${Math.round(delay/1000)}s.`);
-                await new Promise(resolve => setTimeout(resolve, delay));
-                return tryNextApiKey(payload, attemptIndex, retryCount + 1); // Tenta a mesma chave novamente
-            }
-            
-            // Se as retentativas falharam para esta chave, tenta a próxima
-            return tryNextApiKey(payload, attemptIndex + 1, 0);
         }
-
-        const result = await response.json();
-        
-        // Se a chave funcionou, atualiza o índice global e o indicador visual
-        currentGeminiApiKeyIndex = geminiApiKeys.indexOf(apiKey);
-        updateActiveApiKeyIndicator();
-        return result; // Retorna o resultado bem-sucedido
-
-    } catch (error) {
-        console.error(`Erro de rede ou desconhecido com a chave ${attemptIndex + 1}:`, error);
-        // Em caso de erro de rede, tenta a próxima chave
-        return tryNextApiKey(payload, attemptIndex + 1, 0);
     }
+
+    const stillAvailable = getAvailableGeminiKeyEntries({ skipUiRefresh: true });
+    if (stillAvailable.length === 0) {
+        const exhaustedError = new Error('Todas as chaves de API estão indisponíveis no momento.');
+        exhaustedError.code = 'NO_AVAILABLE_KEYS';
+        exhaustedError.userMessage = 'Todas as chaves de IA ficaram temporariamente indisponíveis. Revise suas chaves ou aguarde a liberação automática.';
+        throw exhaustedError;
+    }
+
+    const finalError = lastError || new Error('Não foi possível se comunicar com a API Gemini.');
+    if (!finalError.userMessage) {
+        finalError.userMessage = 'Não foi possível se comunicar com a API Gemini. Verifique suas chaves ou tente novamente em alguns minutos.';
+    }
+    throw finalError;
 }
 
 
@@ -279,8 +818,8 @@ async function checkAndSendDailyNotification() {
     }
 
     // 2. Verifica se a API de IA está pronta
-    if (!isGeminiApiReady) {
-        console.log("API da IA não está pronta. Abortando notificação.");
+    if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+        console.log("Nenhuma chave de IA disponível para gerar a notificação.");
         return;
     }
     
@@ -301,11 +840,11 @@ async function checkAndSendDailyNotification() {
 
     // 4. Gera um insight rápido da IA como resumo do dia
     const insightPrompt = `
-        Analise os dados financeiros a seguir.
-        Sua tarefa é fornecer um insight MUITO CURTO e direto (máximo de 2 frases) para ser usado em uma notificação.
-        Foque em UMA informação útil para o usuário saber hoje, como o saldo atual ou o total de despesas pendentes.
-        Exemplo: "Seu saldo atual é de R$ 1.234,56 e você possui R$ 500,00 em contas pendentes."
-        Responda apenas com o texto do insight, sem formatação.
+        Você está assessorando um casal que precisa de lembretes objetivos para economizar.
+        Gere um insight muito curto (máximo de 2 frases) pronto para uma notificação.
+        Destaque o ponto mais urgente para hoje: corte de gasto não essencial, pagamento essencial pendente ou status de orçamento/caixinha.
+        Jamais realize cálculos ou estimativas — use apenas os números fornecidos.
+        Responda somente com texto simples, sem formatação ou emojis.
 
         DADOS:
         ${getFinancialDataForAI()}
@@ -371,9 +910,9 @@ async function checkAndSendDailyNotification() {
 // --- NOVO: Função para Enviar Notificação de Teste ---
 async function sendTestNotification() {
     // 1. Verifica se a API de IA está pronta
-    if (!isGeminiApiReady) {
-        showToast("API da IA não está pronta. Configure suas chaves de API.", "error");
-        console.log("API da IA não está pronta. Abortando notificação de teste.");
+    if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+        showToast("Nenhuma chave de IA disponível. Configure ou libere suas chaves de API.", "error");
+        console.log("Sem chaves de IA disponíveis. Abortando notificação de teste.");
         return;
     }
     
@@ -549,6 +1088,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const clearChatButton = document.getElementById('clear-chat-button');
     const activeApiKeyIndicator = document.getElementById('active-api-key-indicator');
     const chatBackButton = document.getElementById('chat-back-button');
+    apiKeyStatusListElement = document.getElementById('api-key-status-list');
+    const resetApiKeyStatusButton = document.getElementById('reset-api-key-status-button');
 
     // Elementos das Categorias
     const addCategoryButton = document.getElementById('add-new-category-button');
@@ -729,10 +1270,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         onSnapshot(getUserDocumentRef('settings', 'aiConfig'), (docSnap) => {
             if (docSnap.exists()) {
                 const data = docSnap.data();
-                aiConfig.aiPersona = data.aiPersona || "Você é um educador financeiro especialista...";
+                aiConfig.aiPersona = data.aiPersona || "Você é uma mentora financeira acolhedora e objetiva que orienta um casal brasileiro a cortar supérfluos, priorizar contas essenciais e seguir as metas do app.";
                 aiConfig.aiPersonality = data.aiPersonality || "";
             } else {
-                 aiConfig.aiPersona = "Você é um educador financeiro especialista...";
+                 aiConfig.aiPersona = "Você é uma mentora financeira acolhedora e objetiva que orienta um casal brasileiro a cortar supérfluos, priorizar contas essenciais e seguir as metas do app.";
                  aiConfig.aiPersonality = "";
             }
             // Popula os campos da UI com os valores carregados ou padrão
@@ -794,21 +1335,25 @@ document.addEventListener('DOMContentLoaded', async () => {
                     input.value = geminiApiKeys[index] || '';
                 });
                 updateApiModalStatus("Chaves de API carregadas.", "info");
-                isGeminiApiReady = geminiApiKeys.some(key => key.trim() !== ''); // Pronto se houver qualquer chave
+                syncGeminiApiKeyHealthWithKeys();
                 console.log("Chaves de API Gemini carregadas do Firestore.");
             } else {
                 geminiApiKeys = [];
+                geminiApiKeyHealth = [];
+                persistGeminiApiKeyHealth();
                 modalApiKeyInputs.forEach(input => input.value = ''); // Limpa os campos
                 updateApiModalStatus("Nenhuma chave de API salva ainda. Por favor, insira e salve.", "info");
-                isGeminiApiReady = false;
                 console.log("Chaves de API Gemini não encontradas no Firestore.");
             }
+            isGeminiApiReady = hasAvailableGeminiKey({ skipUiRefresh: true });
+            renderApiKeyStatusList();
             updateChatUIState();
         }, (error) => {
             console.error("Erro ao carregar Chaves de API Gemini do Firestore:", error);
             geminiApiKeys = [];
             updateApiModalStatus(`Erro ao carregar chaves de API: ${error.message}`, "error");
             isGeminiApiReady = false;
+            renderApiKeyStatusList();
             updateChatUIState();
         });
 
@@ -991,8 +1536,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (apiKeyRef) {
                 await setDoc(apiKeyRef, { keys: keysToSave });
                 geminiApiKeys = keysToSave; // Atualiza o array local
+                syncGeminiApiKeyHealthWithKeys();
                 updateApiModalStatus("Chaves de API salvas com sucesso!", "success");
-                isGeminiApiReady = geminiApiKeys.some(key => key.trim() !== '');
+                isGeminiApiReady = hasAvailableGeminiKey({ skipUiRefresh: true });
+                renderApiKeyStatusList();
                 updateChatUIState();
                 console.log("Chaves de API Gemini salvas no Firestore.");
             }
@@ -2132,13 +2679,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     
     // Função para atualizar o indicador visual da chave de API ativa
     function updateActiveApiKeyIndicator() {
-        const validKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
-        if (validKeys.length > 0) {
-            activeApiKeyIndicator.textContent = `Chave ${currentGeminiApiKeyIndex + 1}/${validKeys.length}`;
-            activeApiKeyIndicator.classList.remove('hidden');
-        } else {
-            activeApiKeyIndicator.classList.add('hidden');
+        if (!activeApiKeyIndicator) {
+            return;
         }
+        const configuredKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
+        if (configuredKeys.length === 0) {
+            activeApiKeyIndicator.textContent = '';
+            activeApiKeyIndicator.classList.add('hidden');
+            return;
+        }
+
+        const availableEntries = getAvailableGeminiKeyEntries({ skipUiRefresh: true });
+        const activeIndexDisplay = Math.min(Math.max(currentGeminiApiKeyIndex + 1, 1), configuredKeys.length);
+
+        if (availableEntries.length === 0) {
+            activeApiKeyIndicator.textContent = `Chaves pausadas (${configuredKeys.length} configuradas)`;
+        } else {
+            activeApiKeyIndicator.textContent = `Chave ativa: ${activeIndexDisplay}/${configuredKeys.length} · Disponíveis: ${availableEntries.length}`;
+        }
+        activeApiKeyIndicator.classList.remove('hidden');
     }
 
     function appendMessage(sender, text, type = 'text') {
@@ -2171,13 +2730,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         if (userMessage.trim() === "") return;
 
-        const validKeys = geminiApiKeys.filter((key) => key && key.trim() !== "");
-        if (!isGeminiApiReady || validKeys.length === 0) {
+        if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
             appendMessage(
                 "ai",
-                'O assistente de IA não está configurado. Por favor, insira pelo menos uma chave de API válida em "Mais Opções".',
+                'Todas as chaves de IA estão pausadas ou inválidas. Abra "Mais Opções > Gerenciar Chaves" para liberar ou adicionar novas chaves.',
                 "error"
             );
+            renderApiKeyStatusList();
+            updateChatUIState();
             return;
         }
 
@@ -2189,15 +2749,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         const persona = aiConfig.aiPersona || "";
         const personality = aiConfig.aiPersonality || "";
 
-        const baseSystemInstruction = `Você é um assistente financeiro especialista. Sua função é analisar os dados fornecidos e responder às perguntas do usuário com base NESSES DADOS.
+        const baseSystemInstruction = `Você é um assistente financeiro dedicado a orientar um casal brasileiro que está aprendendo educação financeira. O foco absoluto é economizar, cortar gastos não essenciais, proteger despesas essenciais e manter as metas configuradas no app.
 
 <strong>REGRAS DE COMPORTAMENTO CRÍTICAS E INVIOLÁVEIS:</strong>
-1.  <strong>NÃO FAÇA CÁLCULOS NEM CONTAGENS:</strong> Você está **TERMINANTEMENTE PROIBIDO** de somar valores ou contar itens de listas.
-2.  <strong>USE OS TOTAIS FORNECIDOS:</strong> Para responder sobre saldos, totais ou quantidades, você **DEVE** usar os valores pré-calculados que estão na seção "RESUMO FINANCEIRO (DADOS PRÉ-CALCULADOS)". Por exemplo, se perguntarem o número de despesas pendentes, use o valor de "Quantidade de Despesas Pendentes".
-3.  <strong>SEJA UM APRESENTADOR DE DADOS:</strong> Sua principal função é apresentar os dados que foram fornecidos a você. Se o usuário pedir para listar as despesas pendentes, use a "LISTA DETALHADA DE TRANSAÇÕES PENDENTES".
-4.  <strong>BASEADO EM DADOS, SEM ALARMISMO:</strong> Suas análises devem ser 100% baseadas nos dados fornecidos. Não use linguagem alarmista como "situação crítica". Em vez disso, aponte os fatos. Ex: "Observei que o valor total de suas despesas pendentes é maior que o seu saldo disponível."
-5.  <strong>NÃO PEÇA INFORMAÇÕES NEM REALIZE AÇÕES:</strong> Você já tem todos os dados. Você não pode adicionar, editar ou apagar nada. NUNCA peça ao usuário para registrar transações ou sugira que você pode fazer algo por ele. Se uma informação não está no resumo, diga que não a encontrou.
-6.  <strong>PERSONA E FORMATAÇÃO:</strong> Siga estritamente o papel e o tom definidos abaixo e use apenas HTML básico (<strong>, <br>, <ul>, <li>). NUNCA use Markdown.
+1.  <strong>NÃO FAÇA CÁLCULOS NEM CONTAGENS:</strong> Você está <strong>terminantemente proibido</strong> de somar valores, calcular diferenças ou contar itens. Use apenas os números já prontos.
+2.  <strong>USE OS TOTAIS FORNECIDOS:</strong> Sempre cite exatamente os valores exibidos nas seções "RESUMO FINANCEIRO", "Maiores gastos" e similares. Se algo não estiver nos dados, admita que não encontrou.
+3.  <strong>SEJA UM APRESENTADOR DE DADOS:</strong> Ao responder, aponte explicitamente de onde veio a informação (por exemplo, "no resumo do mês" ou "nas despesas pendentes").
+4.  <strong>FOCO EM ECONOMIA:</strong> A cada resposta, destaque oportunidades de cortar gastos não essenciais, renegociar despesas e reforçar o pagamento do que é essencial.
+5.  <strong>METAS E CAIXINHAS:</strong> Sempre que os dados trouxerem orçamentos ou caixinhas, mencione-os para reforçar prioridades e sugerir próximos passos sem recalcular valores.
+6.  <strong>NÃO PEÇA AÇÕES PARA VOCÊ MESMO:</strong> Você não adiciona nem altera dados. Oriente o casal a agir por conta própria caso necessário.
+7.  <strong>TOM E FORMATAÇÃO:</strong> Fale de forma acolhedora, direta e inclusiva (use "vocês"). Limite-se a HTML básico (<strong>, <br>, <ul>, <li>) e a respostas curtas (máximo de 6 frases ou 6 itens).
+8.  <strong>PERSONA:</strong> Siga o papel e o tom definidos abaixo sem inventar personas adicionais.
     *   <strong>Personagem:</strong> ${persona}
     *   <strong>Personalidade:</strong> ${personality}
 ---`;
@@ -2242,7 +2804,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         } catch (error) {
             console.error('Erro ao chamar a API Gemini:', error);
-            appendMessage('ai', `Erro de comunicação com a IA. ${error.message}`, 'error');
+            const friendlyMessage = error.userMessage || `Erro de comunicação com a IA. ${error.message}`;
+            appendMessage('ai', friendlyMessage, 'error');
+            renderApiKeyStatusList();
+            updateChatUIState();
         } finally {
             if (chatHistory.length > 20) {
                 chatHistory = chatHistory.slice(chatHistory.length - 20);
@@ -2263,9 +2828,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             </div>
         `;
 
-        const validKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
-        if (!isGeminiApiReady || validKeys.length === 0) {
-            insightsContentArea.innerHTML = '<p class="text-red-500">O assistente de IA não está configurado. Por favor, insira sua chave da API Gemini nas "Mais Opções".</p>';
+        if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+            insightsContentArea.innerHTML = '<p class="text-red-500">Todas as chaves da IA estão pausadas ou inválidas. Revise-as em "Mais Opções &gt; Gerenciar Chaves".</p>';
+            renderApiKeyStatusList();
+            updateChatUIState();
             return;
         }
 
@@ -2273,15 +2839,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         const financialData = getFinancialDataForAI();
 
         const insightPrompt = `
-            Analise os dados financeiros a seguir.
-            Sua tarefa é fornecer um insight CURTO e ACIONÁVEL em no máximo 3 frases.
-            Foque em apenas UM ponto principal: o maior gasto, uma oportunidade de economia ou um alerta importante (como contas pendentes atrasadas).
-            
-            REGRAS DE FORMATAÇÃO (OBRIGATÓRIO):
-            1.  **Use APENAS tags HTML**.
-            2.  Use <strong> para títulos ou alertas. Ex: <strong>Alerta de Gastos</strong>.
-            3.  Use <br> para quebras de linha.
-            4.  **NUNCA, EM HIPÓTESE ALGUMA, use Markdown (*, **, _, #, etc.)**. O uso de Markdown quebrará a interface.
+            Você está assessorando um casal brasileiro que busca economizar.
+            Leia os dados abaixo e produza um único insight acionável com no máximo 3 frases.
+            Priorize alertas sobre cortes de gastos não essenciais, reforço das despesas essenciais e andamento de orçamentos ou caixinhas.
+            Jamais faça cálculos, estimativas ou somas: repita exatamente os valores que encontrar.
+
+            FORMATAÇÃO OBRIGATÓRIA:
+            1. Use apenas tags HTML simples.
+            2. Utilize <strong> para o título ou alerta principal.
+            3. Use <br> para quebras de linha.
+            4. Não utilize Markdown nem emojis.
 
             DADOS PARA ANÁLISE:
             ${financialData}
@@ -2318,8 +2885,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 insightsContentArea.innerHTML = '<p class="text-red-500">Não foi possível gerar insights financeiros neste momento.</p>';
             }
         } catch (error) {
-            insightsContentArea.innerHTML = `<p class="text-red-500">Erro ao comunicar com a IA para insights. ${error.message || 'Verifique sua conexão.'}</p>`;
+            const friendlyMessage = error.userMessage || error.message || 'Verifique sua conexão.';
+            insightsContentArea.innerHTML = `<p class="text-red-500">Erro ao comunicar com a IA para insights. ${friendlyMessage}</p>`;
             console.error('Erro ao chamar a API Gemini para Insights:', error);
+            renderApiKeyStatusList();
+            updateChatUIState();
         }
     }
     
@@ -2329,10 +2899,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         budgetOptimizationText.innerHTML = '';
         budgetOptimizationLoadingIndicator.classList.remove('hidden');
 
-        const validKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
-        if (!isGeminiApiReady || validKeys.length === 0) {
-            budgetOptimizationText.innerHTML = '<p class="text-red-500">O assistente de IA não está configurado. Por favor, insira sua chave da API Gemini nas "Mais Opções".</p>';
+        if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+            budgetOptimizationText.innerHTML = '<p class="text-red-500">Todas as chaves da IA estão pausadas ou inválidas. Revise-as em "Mais Opções &gt; Gerenciar Chaves".</p>';
             budgetOptimizationLoadingIndicator.classList.add('hidden');
+            renderApiKeyStatusList();
+            updateChatUIState();
             return;
         }
 
@@ -2354,10 +2925,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         budgetDataString += "<br>--- Fim dos Dados de Orçamento ---<br><br>";
 
         const optimizationPrompt =
-            `Com base nos seguintes dados de orçamento do usuário, forneça sugestões claras e acionáveis para otimizar os gastos e gerenciar melhor o dinheiro. ` +
-            `Seja direto, prático e objetivo, como um consultor financeiro que não hesita em apontar onde o usuário pode melhorar. ` +
+            `Você está ajudando um casal brasileiro a revisar os orçamentos do mês. ` +
+            `Entregue orientações objetivas para proteger despesas essenciais, cortar supérfluos e realocar valores conforme necessário. ` +
+            `Nunca faça cálculos ou crie novos números: repita apenas os valores prontos. ` +
             `Use títulos em negrito (<strong>), listas não ordenadas (<ul>, <li>) e quebras de linha (<br>). ` +
-            `NUNCA use Markdown (*, **, _, #, etc.). ` +
+            `Jamais utilize Markdown, emojis ou textos fora desse formato. ` +
             `Aqui estão os dados: <br><br>${budgetDataString}`;
 
         const payload = {
@@ -2391,8 +2963,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 budgetOptimizationText.innerHTML = '<p class="text-red-500">Não foi possível gerar sugestões de otimização de orçamento neste momento.</p>';
             }
         } catch (error) {
-            budgetOptimizationText.innerHTML = `<p class="text-red-500">Erro ao comunicar com a IA para otimização. ${error.message || 'Verifique sua conexão.'}</p>`;
+            const friendlyMessage = error.userMessage || error.message || 'Verifique sua conexão.';
+            budgetOptimizationText.innerHTML = `<p class="text-red-500">Erro ao comunicar com a IA para otimização. ${friendlyMessage}</p>`;
             console.error('Erro ao chamar a API Gemini para Otimização de Orçamento:', error);
+            renderApiKeyStatusList();
+            updateChatUIState();
         } finally {
             budgetOptimizationLoadingIndicator.classList.add('hidden');
         }
@@ -2415,7 +2990,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function updateApiModalStatus(message, type = 'info') {
         apiModalStatusMessageDiv.classList.remove('hidden', 'bg-blue-100', 'border-blue-500', 'text-blue-700', 'bg-green-100', 'border-green-500', 'text-green-700', 'bg-red-100', 'border-red-500', 'text-red-700');
-        
+
         if (type === 'info') {
             apiModalStatusMessageDiv.classList.add('bg-blue-100', 'border-blue-500', 'text-blue-700');
         } else if (type === 'success') {
@@ -2430,6 +3005,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         setTimeout(() => {
             apiModalStatusMessageDiv.classList.add('hidden');
         }, 5000);
+    }
+
+    if (resetApiKeyStatusButton) {
+        resetApiKeyStatusButton.addEventListener('click', () => {
+            resetApiKeyHealth(true);
+            updateApiModalStatus('Chaves liberadas. Se o limite continuar, adicione novas chaves ou aguarde alguns minutos.', 'success');
+            renderApiKeyStatusList();
+            updateChatUIState();
+        });
     }
 
     // --- Configuração e Inicialização do Firebase ---
@@ -2609,29 +3193,62 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Função para atualizar o estado da UI do chat (habilitado/desabilitado)
     function updateChatUIState() {
-        const hasValidKey = geminiApiKeys.some(key => key.trim() !== '');
-        if (hasValidKey) {
-            isGeminiApiReady = true;
-            chatInput.disabled = false;
-            sendButton.disabled = false;
-            refreshChatDataButton.disabled = false;
-            chatInput.placeholder = "Digite a sua mensagem...";
-            // Verifica se a mensagem de "insira a sua chave" ainda está presente e a remove
+        const configuredKeys = geminiApiKeys.filter(key => key && key.trim() !== '');
+        const availableEntries = getAvailableGeminiKeyEntries({ skipUiRefresh: true });
+        const hasConfiguredKey = configuredKeys.length > 0;
+        const hasAvailableKeyNow = availableEntries.length > 0;
+
+        isGeminiApiReady = hasAvailableKeyNow;
+
+        if (hasAvailableKeyNow) {
+            if (chatInput) {
+                chatInput.disabled = false;
+                chatInput.placeholder = "Digite a sua mensagem...";
+            }
+            if (sendButton) {
+                sendButton.disabled = false;
+            }
+            if (refreshChatDataButton) {
+                refreshChatDataButton.disabled = false;
+            }
+            if (hasWarnedAllKeysBlocked) {
+                hasWarnedAllKeysBlocked = false;
+            }
             const initialAiMessage = chatMessagesDiv.querySelector('.flex.justify-start .bg-gray-100');
             if (initialAiMessage && initialAiMessage.textContent.includes('Por favor, insira sua chave')) {
-                chatMessagesDiv.innerHTML = ''; // Limpa a div de mensagens
+                chatMessagesDiv.innerHTML = '';
                 appendMessage('ai', 'Assistente de IA pronto! Como posso ajudar?', 'info');
             }
-            updateActiveApiKeyIndicator(); // Mostra o indicador
         } else {
-            isGeminiApiReady = false;
-            chatInput.disabled = true;
-            sendButton.disabled = true;
-            refreshChatDataButton.disabled = true;
-            chatInput.placeholder = "Assistente não configurado...";
-            activeApiKeyIndicator.classList.add('hidden'); // Esconde o indicador
+            if (chatInput) {
+                chatInput.disabled = true;
+                chatInput.placeholder = hasConfiguredKey
+                    ? 'Todas as chaves estão em pausa. Ajuste em "Mais Opções > Gerenciar Chaves".'
+                    : 'Assistente não configurado...';
+            }
+            if (sendButton) {
+                sendButton.disabled = true;
+            }
+            if (refreshChatDataButton) {
+                refreshChatDataButton.disabled = true;
+            }
+
+            if (hasConfiguredKey && !hasWarnedAllKeysBlocked) {
+                appendMessage('ai', 'Todas as chaves de IA ficaram temporariamente indisponíveis. Abra "Mais Opções > Gerenciar Chaves" para liberar ou incluir novas chaves.', 'error');
+                hasWarnedAllKeysBlocked = true;
+            } else if (!hasConfiguredKey) {
+                hasWarnedAllKeysBlocked = false;
+            }
         }
+
+        updateActiveApiKeyIndicator();
     }
+
+    scheduleApiKeyUiRefresh = () => {
+        renderApiKeyStatusList();
+        updateChatUIState();
+    };
+    scheduleApiKeyUiRefresh();
 
 
     // Event listeners do Modal de Categoria
@@ -3272,10 +3889,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         categoryOptimizationSuggestions.innerHTML = '';
         categoryOptimizationLoadingIndicator.classList.remove('hidden');
 
-        const validKeys = geminiApiKeys.filter((key) => key && key.trim() !== "");
-        if (!isGeminiApiReady || validKeys.length === 0) {
-            categoryOptimizationSuggestions.innerHTML = '<p class="text-red-500">O assistente de IA não está configurado.</p>';
+        if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+            categoryOptimizationSuggestions.innerHTML = '<p class="text-red-500">Todas as chaves da IA estão pausadas ou inválidas. Revise-as em "Mais Opções &gt; Gerenciar Chaves".</p>';
             categoryOptimizationLoadingIndicator.classList.add('hidden');
+            renderApiKeyStatusList();
+            updateChatUIState();
             return;
         }
 
@@ -3350,7 +3968,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             renderCategoryOptimizationSuggestions(suggestions);
         } catch (error) {
             console.error("Erro ao otimizar categorias:", error);
-            categoryOptimizationSuggestions.innerHTML = `<p class="text-red-500">Erro ao obter sugestões da IA. Tente novamente.</p>`;
+            const friendlyMessage = error.userMessage || error.message || 'Tente novamente em instantes.';
+            categoryOptimizationSuggestions.innerHTML = `<p class="text-red-500">Erro ao obter sugestões da IA. ${friendlyMessage}</p>`;
+            renderApiKeyStatusList();
+            updateChatUIState();
         } finally {
             categoryOptimizationLoadingIndicator.classList.add('hidden');
         }
@@ -3604,9 +4225,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        const validKeys = geminiApiKeys.filter((key) => key && key.trim() !== "");
-        if (!isGeminiApiReady || validKeys.length === 0) {
-            showToast("O assistente de IA não está configurado.", "error");
+        if (!hasAvailableGeminiKey({ skipUiRefresh: true })) {
+            showToast("Todas as chaves da IA estão pausadas ou inválidas. Revise-as em 'Mais Opções > Gerenciar Chaves'.", "error");
+            renderApiKeyStatusList();
+            updateChatUIState();
             return;
         }
 
@@ -3643,6 +4265,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             3.  **Sugestão de Categoria:** Para cada despesa NOVA, analise a 'description' e compare-a com a lista de 'categorias_existentes'.
                 - Se a descrição se encaixa bem em uma categoria existente, use o nome exato dessa categoria em 'suggestedCategoryName'.
                 - Se nenhuma categoria existente se encaixar bem, crie um nome de categoria novo, claro e conciso, para 'suggestedCategoryName'.
+            4.  **SEM CÁLCULOS:** Copie exatamente o valor informado em cada linha. Não some, subtraia ou estime qualquer número.
             
             ---
             DADOS FORNECIDOS PARA ANÁLISE:
@@ -3685,7 +4308,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         } catch (error) {
             console.error("Erro ao analisar despesas com IA:", error);
-            showToast("Erro ao processar a lista. Verifique o formato e tente novamente.", "error");
+            showToast(error.userMessage || "Erro ao processar a lista. Verifique o formato e tente novamente.", "error");
+            renderApiKeyStatusList();
+            updateChatUIState();
         } finally {
             button.disabled = false;
             buttonText.textContent = 'Analisar com IA';


### PR DESCRIPTION
## Summary
- reset cached Gemini key health when the same key fingerprint reloads to avoid permanent invalid flags
- treat HTTP 400 responses as user input issues instead of blocking the API key and surface a clearer hint
- return a friendlier error when the requested Gemini model is unavailable without disabling the key

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6d1654bd08325ad843cbee56aa843