### PR TITLE
Refactor Gemini key handling to single key configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
                         </button>
                         <div class="text-center">
                             <h2 class="text-xl font-bold text-[var(--color-heading-green)]">Assistente IA</h2>
-                            <p id="active-api-key-indicator" class="text-xs text-gray-500 hidden">Chave 1/5</p>
+                            <p id="active-api-key-indicator" class="text-xs text-gray-500 hidden">Configure sua chave do Gemini</p>
                         </div>
                         <div class="relative">
                              <button class="action-menu-button p-2 rounded-full hover:bg-gray-100" data-id="chat-options">
@@ -280,15 +280,15 @@
                          <i class="fa-solid fa-chevron-right text-gray-400"></i>
                     </a>
                     
-                     <!-- Gerenciar Chaves de API -->
+                    <!-- Gerenciar Chave de API -->
                     <a href="#" data-page="api-management" class="nav-link bg-white p-4 rounded-xl shadow-sm flex items-center justify-between hover:bg-gray-50 transition">
                         <div class="flex items-center">
                             <div class="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center mr-4">
                                 <i class="fa-solid fa-key text-[var(--color-option-icon-green)]"></i>
                             </div>
                             <div>
-                                <p class="font-semibold text-gray-800">Gerenciar Chaves de API</p>
-                                <p class="text-sm text-gray-500">Configure suas chaves do Gemini.</p>
+                                <p class="font-semibold text-gray-800">Gerenciar Chave de API</p>
+                                <p class="text-sm text-gray-500">Configure sua chave do Gemini.</p>
                             </div>
                         </div>
                         <i class="fa-solid fa-chevron-right text-gray-400"></i>
@@ -595,22 +595,18 @@
     <div id="api-keys-modal" class="modal">
         <div class="modal-content relative">
             <span id="close-api-keys-modal" class="close-button">&times;</span>
-            <h2 class="text-2xl font-bold mb-2">Gerenciar Chaves de API Gemini</h2>
-            <p class="text-gray-500 mb-4">Insira até 5 chaves de API. O sistema alternará entre elas e colocará em pausa automática quando o limite for atingido.</p>
+            <h2 class="text-2xl font-bold mb-2">Gerenciar Chave de API Gemini</h2>
+            <p class="text-gray-500 mb-4">Insira sua chave de API do Gemini. Ela será usada em todas as solicitações; se o limite for atingido, você poderá liberá-la após o tempo de espera.</p>
             <div id="api-modal-status-message" class="hidden p-4 mb-4 text-sm rounded-lg" role="alert">
                 <span id="api-modal-message-text"></span>
             </div>
             <div class="space-y-3">
-                <input type="text" id="modal-api-key-1" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 1">
-                <input type="text" id="modal-api-key-2" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 2">
-                <input type="text" id="modal-api-key-3" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 3">
-                <input type="text" id="modal-api-key-4" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 4">
-                <input type="text" id="modal-api-key-5" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Chave de API 5">
+                <input type="text" id="modal-api-key" class="w-full border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-blue-primary)]" placeholder="Cole aqui sua chave de API do Gemini">
             </div>
             <div id="api-key-status-list" class="hidden mt-4 text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3 space-y-2"></div>
             <div class="flex flex-col gap-3 mt-6 sm:flex-row sm:items-center sm:justify-between">
-                <button id="reset-api-key-status-button" class="w-full sm:w-auto bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors">Liberar chaves em pausa</button>
-                <button id="save-api-keys-modal-button" class="w-full sm:w-auto bg-[var(--color-blue-primary)] text-white font-bold py-2 px-4 rounded-lg">Salvar Chaves</button>
+                <button id="reset-api-key-status-button" class="w-full sm:w-auto bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors">Liberar chave em pausa</button>
+                <button id="save-api-keys-modal-button" class="w-full sm:w-auto bg-[var(--color-blue-primary)] text-white font-bold py-2 px-4 rounded-lg">Salvar Chave</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the previous Gemini API key rotation with a single-key status tracker and refreshed retry logic
- update Firestore persistence, chat messaging, and status indicators to reflect the single-key workflow
- simplify the API management modal to capture just one Gemini key and convert any legacy array data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e5ffe31883258961ec5c5016cefc